### PR TITLE
prevent addon registration when Blender is run in background

### DIFF
--- a/src/animation_motion_trail_updated.py
+++ b/src/animation_motion_trail_updated.py
@@ -3800,6 +3800,8 @@ classes = (
 # Register panel manually to allow renaming it
 
 def register():
+	if bpy.app.background:
+		return 
 	for cls in classes:
 		bpy.utils.register_class(cls)
 


### PR DESCRIPTION
When Blender is run in the background in CLI (`blender -b`), don't register the addon.

Should fix #3